### PR TITLE
Deploy from Travis CI to Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,10 @@ branches:
 
 notifications:
   email: false
+
+deploy:
+  provider: heroku
+  api_key:
+    secure: qqIWRJTRUZu3LqsbkZCyAD5jSB34CyC/GVPznqM1Qm2LxEMsDDdR1hypZ+o2nMYryaHmjSM8iQ9rsMjJNMmuR8p0HdFlgj3XPGwKQaGh4hBwhc4whRv8FLqU58Rpx3WSwxKFM6KM+XtNIeqlJ3pnSERoWHi+srg3cMTLrryoRj8nDRczMP+DRLww5HpPkFlYYa70s+378a7ooQB2rq+6R/Fg4CsqfxTe3x2SHx8u6BivRl65xj9ntl27xRMIxSmRpnV7cHkxTf+iKnoR++QkPGX0F2s6bs4u2ufzMhhD3d2Whu+rYlsJFW7g+4vvmarJ/Q43PWYm2gcTz4Mua37PUt9LjHWqyV9VEU6yj8XsVt5l1rzhm/WKd1C/Zh4caw+8/ibg18J7/LTx9e/AIqYzSs6ebhTHyZTGFx93iFFvbqBnKwVq5khMo1uWadlE+Xnf0mnlaqV9ZEyjxYzKeAdj1fae6BDxFL7Iavv0y1VpDsd3XG96pmN+4SjFAZVsZ6ZRLOrCEZnSlK/17LC9YZjVlPUDmt9Vqx9MUyy6M0o70X9nTvOEFIfook5b1ayGm7mf+BjFOe+HmnN1e/nM0Rge6IHfFPYRqJU10KhL0kny69QKH5EuI+klslA2S6s7STkkhYLj+I1nDeCLbMt438jlJ9w0ATMa+gCOFO6nMcM61Ys=
+  app:
+    master: sample-rev4

--- a/.travis/docker-compose.yml
+++ b/.travis/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - node
 
   chrome:
-    image: selenium/standalone-chrome-debug
+    image: selenium/standalone-chrome
     ports:
       - 5900:5900
 

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: curl -o- -L https://yarnpkg.com/install.sh | bash && PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH" && cd frontend && yarn install && yarn release && cd ../ && bundle exec rails s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - ./public/assets/:/app/public/assets:cached
 
   chrome:
-    image: selenium/standalone-chrome-debug
+    image: selenium/standalone-chrome
     ports:
       - 5900:5900
 

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -4,10 +4,15 @@ require "capybara/rspec"
 require "selenium-webdriver"
 
 Capybara.register_driver :selenium_remote do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: {
+      args: ["--headless", "--no-sandbox", "--disable--gpu", "--window-size=1280x800"],
+    },
+  )
   Capybara::Selenium::Driver.new(app,
                                  url: "http://chrome:4444/wd/hub",
                                  browser: :remote,
-                                 desired_capabilities: :chrome)
+                                 desired_capabilities: capabilities)
 end
 
 Capybara.default_driver = :rake_test


### PR DESCRIPTION
- Enable staging deployment through [Review Apps](https://devcenter.heroku.com/articles/github-integration-review-apps)
- Production deployment from Travis CI to Heroku: only when merging feature branch to master