### PR TITLE
Update rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,12 @@ AllCops:
     - "vendor/**/*"
     - "frontend/**/*"
 
+# ref. https://github.com/bbatsov/ruby-style-guide#indent-conditional-assignment
+Layout/EndAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: keyword
+  AutoCorrect: true
+
 Layout/IndentArray:
   EnforcedStyle: consistent
 
@@ -21,12 +27,6 @@ Lint/AmbiguousBlockAssociation:
 # Allow variable name starting with "_"
 Lint/UnderscorePrefixedVariableName:
   Enabled: false
-
-# ref. https://github.com/bbatsov/ruby-style-guide#indent-conditional-assignment
-Lint/EndAlignment:
-  Enabled: true
-  EnforcedStyleAlignWith: keyword
-  AutoCorrect: true
 
 Metrics/BlockLength:
   CountComments: false
@@ -89,5 +89,9 @@ Style/StringLiterals:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+

--- a/bin/rspec
+++ b/bin/rspec
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 begin
-  load File.expand_path("../spring", __FILE__)
+  load File.expand_path("spring", __dir__)
 rescue LoadError => e
   raise unless e.message.include?("spring")
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require "spec_helper"
 ENV["RAILS_ENV"] ||= "test"
-require File.expand_path("../../config/environment", __FILE__)
+require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require "rspec/rails"


### PR DESCRIPTION
* Style/TrailingCommaInLiteral is splited into two new cops since v0.53.0
  * see. https://github.com/bbatsov/rubocop/issues/5404
* Lint/EndAlignment is moved to Layout namespace
  * see. https://github.com/bbatsov/rubocop/issues/4704