### PR TITLE
Chapter 14 Following users

### DIFF
--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -3,12 +3,14 @@
 class RelationshipsController < ApplicationController
   before_action :authenticate_user!
 
+  # TODO: Enable to follow user through Ajax request
   def create
     user = User.find(params[:followed_id])
     current_user.follow(user) unless current_user.following?(user)
     redirect_to user
   end
 
+  # TODO: Enable to unfollow user through Ajax request
   def destroy
     user = Relationship.find(params[:id]).followed
     current_user.unfollow(user)

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RelationshipsController < ApplicationController
+  before_action :authenticate_user!, before: :create
+
+  def create
+    user = User.find(params[:followed_id])
+    current_user.follow(user) unless current_user.following?(user)
+    redirect_to user
+  end
+end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 class RelationshipsController < ApplicationController
-  before_action :authenticate_user!, before: :create
+  before_action :authenticate_user!
 
   def create
     user = User.find(params[:followed_id])
     current_user.follow(user) unless current_user.following?(user)
+    redirect_to user
+  end
+
+  def destroy
+    user = Relationship.find(params[:id]).followed
+    current_user.unfollow(user)
     redirect_to user
   end
 end

--- a/app/controllers/users/followers_controller.rb
+++ b/app/controllers/users/followers_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Users::FollowersController < ApplicationController
+  before_action :authenticate_user!, only: :index
+
+  def index
+    @title = "Followers"
+    @user = User.find(params[:id])
+    @users = @user.followers.paginate(page: params[:page])
+
+    render "users/show_follow"
+  end
+end

--- a/app/controllers/users/following_controller.rb
+++ b/app/controllers/users/following_controller.rb
@@ -3,5 +3,11 @@
 class Users::FollowingController < ApplicationController
   before_action :authenticate_user!, only: :index
 
-  def index; end
+  def index
+    @title = "Following"
+    @user = User.find(params[:id])
+    @users = @user.following.paginate(page: params[:page])
+
+    render "users/show_follow"
+  end
 end

--- a/app/controllers/users/following_controller.rb
+++ b/app/controllers/users/following_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Users::FollowingController < ApplicationController
+  before_action :authenticate_user!, only: :index
+
+  def index; end
+end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -11,6 +11,7 @@ class Micropost < ApplicationRecord
   has_one_attached :picture
 
   scope :recent, -> { order(created_at: :desc) }
+  scope :of_user, ->(user) { where(user_id: user) }
 
   private
 

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Relationship < ApplicationRecord
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
 class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -3,4 +3,7 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: "User"
   belongs_to :followed, class_name: "User"
+
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,9 +59,9 @@ class User < ApplicationRecord
     reset_sent_at < 2.hours.ago
   end
 
-  # TODO
   def feeds
-    microposts.recent.with_attached_picture
+    scoped_posts = Micropost.includes(:user).recent.with_attached_picture
+    scoped_posts.of_user(following).or(scoped_posts.of_user(self))
   end
 
   def follow(other)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
   has_many :active_relationships, class_name: "Relationship",
                                   foreign_key: "follower_id", dependent: :destroy
 
+  has_many :following, through: :active_relationships, source: :followed
+
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, length: { maximum: 255 },
                     format: { with: VALID_EMAIL_REGEX },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,4 +59,16 @@ class User < ApplicationRecord
   def feeds
     microposts.recent.with_attached_picture
   end
+
+  def follow(other)
+    active_relationships.create(followed_id: other.id)
+  end
+
+  def unfollow(other)
+    active_relationships.find_by(followed_id: other).destroy
+  end
+
+  def following?(other)
+    following.include?(other)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   attr_accessor :remember_token, :activation_token, :reset_token
 
   has_many :microposts, dependent: :destroy
+  has_many :active_relationships, class_name: "Relationship",
+                                  foreign_key: "follower_id", dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, length: { maximum: 255 },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,11 @@ class User < ApplicationRecord
   has_many :active_relationships, class_name: "Relationship",
                                   foreign_key: "follower_id", dependent: :destroy
 
+  has_many :passive_relationships, class_name: "Relationship",
+                                   foreign_key: "followed_id", dependent: :destroy
+
   has_many :following, through: :active_relationships, source: :followed
+  has_many :followers, through: :passive_relationships, source: :follower
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, length: { maximum: 255 },
@@ -70,5 +74,9 @@ class User < ApplicationRecord
 
   def following?(other)
     following.include?(other)
+  end
+
+  def followed?(other)
+    followed.include?(other)
   end
 end

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,0 +1,14 @@
+<div class="stats">
+<%= link_to following_user_index_path(user) do %>
+  <strong id="following" class="stat">
+    <%= user.following.count %>
+  </strong>
+  following
+<% end %>
+<%= link_to followers_user_index_path(user) do %>
+  <strong id="followers" class="stat">
+    <%= user.followers.count %>
+  </strong>
+  followers
+<% end %>
+</div>

--- a/app/views/shared/_user_info.html.erb
+++ b/app/views/shared/_user_info.html.erb
@@ -1,4 +1,4 @@
-<%= link_to gravatar_for(current_user, size: 50), current_user %>
-<h1><%= current_user.name %></h1>
-<span><%= link_to "View my profile", current_user %></span>
-<span><%= pluralize(current_user.microposts.count, "micropost", "microposts") %></span>
+<%= link_to gravatar_for(user, size: 50), user %>
+<h1><%= user.name %></h1>
+<span><%= link_to "View my profile", user %></span>
+<span><b>Microposts: </b><%= pluralize(user.microposts.count, "micropost", "microposts") %></span>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -4,7 +4,7 @@
   <div class="row">
     <aside class="col-md-4">
       <section class="user_info">
-        <%= render "shared/user_info" %>
+        <%= render "shared/user_info", user: current_user %>
       </section>
       <section class="stats">
         <%= render "/shared/stats", user: current_user %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -6,6 +6,9 @@
       <section class="user_info">
         <%= render "shared/user_info" %>
       </section>
+      <section class="stats">
+        <%= render "/shared/stats", user: current_user %>
+      </section>
       <section class="micropost_form">
         <%= render "shared/micropost_form" %>
       </section>

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -1,0 +1,25 @@
+<% provide(:title, @title) %>
+<div class="row">
+  <aside class="col-md-4">
+    <section class="user_info">
+      <%= render "shared/user_info", user: @user %>
+    </section>
+    <section class="stats">
+      <%= render "shared/stats", user: @user %>
+      <div class="user_avatars">
+        <% @users.each do |user| %>
+          <%= link_to gravatar_for(user, size: 30), user %>
+        <% end %>
+      </div>
+    </section>
+  </aside>
+  <div class="col-md-8">
+    <h3><%= @title %></h3>
+    <ul class="users follow">
+      <% @users.each do |user| %>
+        <%= render "users/user", user: user %>
+      <% end %>
+    </ul>
+    <%= will_paginate @users %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,13 +13,13 @@ module App
     config.generators do |g|
       g.assets false
       g.helper false
-      g.test_framekwork :rspec,
-                        fixtures: true,
-                        view_specs: false,
-                        helper_specs: false,
-                        routing_specs: false,
-                        controller_specs: false,
-                        request_specs: true
+      g.test_framework :rspec,
+                       fixtures: true,
+                       view_specs: false,
+                       helper_specs: false,
+                       routing_specs: false,
+                       controller_specs: false,
+                       request_specs: true
     end
 
     config.active_record.default_timezone = :local

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
   end
 
   resources :microposts, only: %w[create destroy]
+  resources :relationships, only: %w[create destroy]
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,15 @@ Rails.application.routes.draw do
 
   get "/signup", to: "users#new"
   post "/signup", to: "users#create"
-  resources :users
+
+  resources :users do
+    member do
+      # なぜか path の postfix に "_index" がついてしまう
+      resources :following, only: :index, module: :users, as: "following_user"
+      resources :followers, only: :index, module: :users, as: "followers_user"
+    end
+  end
+
   namespace :users do
     resources :account_activations, only: :edit
     resources :password_resets, only: %w[new create edit update]

--- a/db/fixtures/01_user.rb
+++ b/db/fixtures/01_user.rb
@@ -19,4 +19,4 @@ users = (2..100).map do |n|
   }
 end
 
-User.seed(:id, users)
+User.seed(users)

--- a/db/fixtures/02_micropost.rb
+++ b/db/fixtures/02_micropost.rb
@@ -9,5 +9,5 @@ users.each do |user|
       user: user,
     }
   end
-  Micropost.seed(:id, microposts)
+  Micropost.seed(microposts)
 end

--- a/db/fixtures/03_relationship.rb
+++ b/db/fixtures/03_relationship.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+user = User.first
+
+users = User.all
+following = users[2..50].map do |followed|
+  {
+    follower_id: user.id,
+    followed_id: followed.id,
+  }
+end
+Relationship.seed(following)
+
+followers = users[3..40].map do |follower|
+  {
+    follower_id: follower.id,
+    followed_id: user.id,
+  }
+end
+Relationship.seed(followers)

--- a/db/migrate/20180503004046_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20180503004046_create_active_storage_tables.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
   def change
@@ -10,7 +12,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.string   :checksum,   null: false
       t.datetime :created_at, null: false
 
-      t.index [ :key ], unique: true
+      t.index [:key], unique: true
     end
 
     create_table :active_storage_attachments do |t|
@@ -20,7 +22,7 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
 
       t.datetime :created_at, null: false
 
-      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.index %i[record_type record_id name blob_id], name: "index_active_storage_attachments_uniqueness", unique: true
     end
   end
 end

--- a/db/migrate/20180511211109_create_relationships.rb
+++ b/db/migrate/20180511211109_create_relationships.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateRelationships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, %i[follower_id followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_03_004046) do
+ActiveRecord::Schema.define(version: 2018_05_11_211109) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -40,6 +40,16 @@ ActiveRecord::Schema.define(version: 2018_05_03_004046) do
     t.datetime "updated_at", null: false
     t.index ["user_id", "created_at"], name: "index_microposts_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_microposts_on_user_id"
+  end
+
+  create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/frontend/src/stylesheets/_users.scss
+++ b/frontend/src/stylesheets/_users.scss
@@ -69,3 +69,18 @@ aside {
     display: block;
   }
 }
+
+.user_avatars {
+  overflow: auto;
+  margin-top: 10px;
+  .gravatar {
+    margin: 1px 1px;
+  }
+  a {
+    padding: 0;
+  }
+}
+
+.users.follow {
+  padding: 0;
+}

--- a/frontend/src/stylesheets/_users.scss
+++ b/frontend/src/stylesheets/_users.scss
@@ -46,3 +46,26 @@ aside {
     border-bottom: 1px solid $gray-lighter;
   }
 }
+
+.stats {
+  overflow: auto;
+  margin-top: 0;
+  padding: 0;
+  a {
+    float: left;
+    padding: 0 10px;
+    border-left: 1px solid $gray-lighter;
+    color: gray;
+    &:first-child {
+      padding-left: 0;
+      border: 0;
+    }
+    &:hover {
+      text-decoration: none;
+      color: blue;
+    }
+  }
+  strong {
+    display: block;
+  }
+}

--- a/spec/factories/relationships.rb
+++ b/spec/factories/relationships.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :relationship do
+  end
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Relationship, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/relationship_spec.rb
+++ b/spec/models/relationship_spec.rb
@@ -3,5 +3,21 @@
 require "rails_helper"
 
 RSpec.describe Relationship, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject { FactoryBot.build(:relationship, follower_id: follower_id, followed_id: followed_id) }
+  let(:follower_id) { FactoryBot.create(:user, :kumiko, :activated).id }
+  let(:followed_id) { FactoryBot.create(:user, :asuka, :activated).id }
+
+  context "when follower_id is blank" do
+    let(:follower_id) { nil }
+    it { is_expected.not_to be_valid }
+  end
+
+  context "when followed_id is blank" do
+    let(:followed_id) { nil }
+    it { is_expected.not_to be_valid }
+  end
+
+  context "both follower_id and followed_id is present" do
+    it { is_expected.to be_valid }
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -135,4 +135,30 @@ RSpec.describe User, type: :model do
 
     it { expect { user.destroy }.to change { Micropost.count }.by(-1) }
   end
+
+  describe "#following?" do
+    let(:kumiko) { FactoryBot.create(:user, :kumiko, :activated) }
+    let(:asuka) { FactoryBot.create(:user, :asuka, :activated) }
+
+    subject { kumiko.following?(asuka) }
+
+    context "when not followed" do
+      it { is_expected.to be false }
+    end
+
+    context "when followed" do
+      before { kumiko.follow(asuka) }
+
+      it { is_expected.to be true }
+    end
+
+    context "when unfollowed" do
+      before do
+        kumiko.follow(asuka)
+        kumiko.unfollow(asuka)
+      end
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -161,4 +161,28 @@ RSpec.describe User, type: :model do
       it { is_expected.to be false }
     end
   end
+
+  describe "#feeds" do
+    let(:kumiko) { FactoryBot.create(:user, :kumiko, :activated, :with_microposts) }
+    let(:asuka) { FactoryBot.create(:user, :asuka, :activated, :with_microposts) }
+    let(:reina) { FactoryBot.create(:user, :dummy, :activated, :with_microposts) }
+
+    subject(:feeds) { kumiko.feeds }
+
+    before do
+      kumiko.follow(asuka)
+    end
+
+    it "includes microposts of user itself" do
+      expect(feeds).to include(kumiko.microposts.first)
+    end
+
+    it "includes microposts of user following" do
+      expect(feeds).to include(asuka.microposts.first)
+    end
+
+    it "doesn't include microposts of user NOT following" do
+      expect(feeds).not_to include(reina.microposts)
+    end
+  end
 end

--- a/spec/requests/relationships/create_request_spec.rb
+++ b/spec/requests/relationships/create_request_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "/relationships", type: :request do
+  describe "POST /relationships" do
+    subject(:create_request) do
+      lambda {
+        post relationships_path, params: { followed_id: followed_id }
+      }
+    end
+
+    let(:user) { FactoryBot.create(:user, :kumiko, :activated) }
+    let(:another) { FactoryBot.create(:user, :asuka, :activated) }
+    let(:followed_id) { another.id }
+
+    context "when not logged in" do
+      it { expect(create_request.call).to redirect_to login_path }
+    end
+
+    context "when logged in" do
+      before do
+        log_in_as user
+      end
+
+      context "when already followed" do
+        before do
+          user.follow(another)
+        end
+
+        it "fails to create active relationship" do
+          expect { create_request.call }.not_to change { Relationship.count }
+        end
+      end
+
+      context "when not followed yet" do
+        it "succeeds to create active relationship" do
+          expect { create_request.call }.to change { Relationship.count }.by(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/relationships/destroy_request_spec.rb
+++ b/spec/requests/relationships/destroy_request_spec.rb
@@ -1,0 +1,51 @@
+
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "/relationship", type: :request do
+  describe "DELETE /relationship" do
+    subject(:destroy_request) do
+      lambda {
+        delete relationship_path(relationship)
+      }
+    end
+
+    let(:user) { FactoryBot.create(:user, :kumiko, :activated) }
+    let(:another) { FactoryBot.create(:user, :asuka, :activated) }
+    let(:relationship) do
+      FactoryBot.create(
+        :relationship,
+        follower_id: user.id,
+        followed_id: another.id,
+      )
+    end
+
+    context "when not logged in" do
+      it { expect(destroy_request.call).to redirect_to login_path }
+    end
+
+    context "when logged in" do
+      before do
+        log_in_as user
+        relationship.reload
+      end
+
+      context "when already followed" do
+        it "succeeds to delete active relationship" do
+          expect { destroy_request.call }.to change { Relationship.count }.by(-1)
+        end
+      end
+
+      context "when not followed yet" do
+        before do
+          user.unfollow(another)
+        end
+
+        xit "fails to delete active relationship" do
+          expect { destroy_request.call }.not_to change { Relationship.count }
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/users/followers/index_request_spec.rb
+++ b/spec/requests/users/followers/index_request_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "/users/:id/followers", type: :request do
+  describe "GET /users/:id/followers" do
+    subject { get followers_user_index_path(user) }
+
+    let(:user) { FactoryBot.create(:user, :kumiko, :activated) }
+    let(:another) { FactoryBot.create(:user, :asuka, :activated) }
+
+    context "when not logged in" do
+      it { is_expected.to redirect_to login_path }
+    end
+
+    context "when logged in" do
+      before do
+        log_in_as(user)
+      end
+
+      it { is_expected.to render_template("users/show_follow") }
+    end
+  end
+end

--- a/spec/requests/users/following/index_request_spec.rb
+++ b/spec/requests/users/following/index_request_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "/users/:id/following", type: :request do
+  describe "GET /users/:id/following" do
+    subject { get following_user_index_path(user) }
+
+    let(:user) { FactoryBot.create(:user, :kumiko, :activated) }
+    let(:another) { FactoryBot.create(:user, :asuka, :activated) }
+
+    context "when not logged in" do
+      it { is_expected.to redirect_to login_path }
+    end
+  end
+end

--- a/spec/requests/users/following/index_request_spec.rb
+++ b/spec/requests/users/following/index_request_spec.rb
@@ -12,5 +12,13 @@ RSpec.describe "/users/:id/following", type: :request do
     context "when not logged in" do
       it { is_expected.to redirect_to login_path }
     end
+
+    context "when logged in" do
+      before do
+        log_in_as(user)
+      end
+
+      it { is_expected.to render_template("users/show_follow") }
+    end
   end
 end


### PR DESCRIPTION
(英語で Description 書くの疲れたので日本語にする…)

[チュートリアル本家](https://railstutorial.jp/chapters/following_users?version=5.1)との差分は以下の通り:
- フォロー/アンフォローのリソースに対して DHH 流ルーティングを採用した
  - `/user/:id/following` および `/user:id/followers`
- `app/viwes/shared/_stats.html.erb` 内部で定義していた `@current_user` をパーシャルの外から渡すことにした
  - ref. https://kadoppe.com/archives/2013/09/rails-partial-template-instance-variables.html