### PR TITLE
Introduce openssl into Dockerfiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - docker-compose -f .travis/docker-compose.yml run --rm spring bin/rails db:create db:migrate
 
 script:
-  - docker-compose -f .travis/docker-compose.yml run --rm spring rspec --profile --format progress
+  - docker-compose -f .travis/docker-compose.yml run --rm spring bundle exec rspec --profile --format progress
 
 branches:
   only:

--- a/docker/rails/Dockerfile.dev
+++ b/docker/rails/Dockerfile.dev
@@ -3,7 +3,7 @@ LABEL maintainer "cheezenaan <cheezenaan@gmail.com>"
 
 ENV \
   APP_ROOT="/app" \
-  DEV_PACKAGES="build-base less libxml2-dev libxslt-dev tzdata" \
+  DEV_PACKAGES="build-base less libxml2-dev libxslt-dev tzdata openssl" \
   ENTRYKIT_VERSION="0.4.0" \
   LANG="C.UTF-8" \
   RAILS_PACKAGES="mysql-dev imagemagick"

--- a/docker/rails/Dockerfile.test
+++ b/docker/rails/Dockerfile.test
@@ -3,7 +3,7 @@ LABEL maintainer "cheezenaan <cheezenaan@gmail.com>"
 
 ENV \
   APP_ROOT="/app" \
-  DEV_PACKAGES="build-base libxml2-dev libxslt-dev tzdata" \
+  DEV_PACKAGES="build-base libxml2-dev libxslt-dev tzdata openssl" \
   DOCKERIZE_VERSION="v0.3.0" \
   ENTRYKIT_VERSION="0.4.0" \
   LANG="C.UTF-8" \


### PR DESCRIPTION
Travis CI が数日前からビルドにコケるようになってから発覚。 
https://travis-ci.org/cheezenaan-sandbox/sample_app_rev4/builds/385895777

`docker build` した際に `wget` が通らなくなってしまったので `apk add --no-cache openssl` する。

```sh
wget https://github.com/progrium/entrykit/releases/download/v0.4.0/entrykit_0.4.0_Linux_x86_64.tgz
Connecting to github.com (192.30.255.112:443)
wget: unable to validate the server's certificate
```

ref. https://github.com/Yelp/dumb-init/issues/73
